### PR TITLE
Fix attempt to access forbidden object

### DIFF
--- a/quest.lua
+++ b/quest.lua
@@ -391,7 +391,7 @@ function CodexQuest:CheckNamePlate()
     local plateList = {}
     for index = 1, something do
         local frame = select(index, WorldFrame:GetChildren())
-        if frame and frame:GetName() and frame:GetName():find("NamePlate%d") and not frame.skinned then
+        if frame and not frame:IsForbidden() and frame:GetName():find("NamePlate%d") and not frame.skinned then
             frame.skinned = 1
             frame.icon = CreateFrame("Frame", nil, frame)
             frame.icon:SetFrameStrata("HIGH")


### PR DESCRIPTION
:GetName is exist when the nameplate is forbidden, we should check if it's forbidden before call :GetName