### PR TITLE
fix "attempt to index a nil value" in CodexQuest:CheckNamePlate()

### DIFF
--- a/quest.lua
+++ b/quest.lua
@@ -391,7 +391,9 @@ function CodexQuest:CheckNamePlate()
     local plateList = {}
     for index = 1, something do
         local frame = select(index, WorldFrame:GetChildren())
-        if frame and not frame:IsForbidden() and frame:GetName():find("NamePlate%d") and not frame.skinned then
+        -- Notice: sometimes frame:GetName() returns nil so we must check it before call :find()
+        --         or an "attempt to index a nil value" error will be threw.
+        if frame and not frame:IsForbidden() and frame:GetName() and frame:GetName():find("NamePlate%d") and not frame.skinned then
             frame.skinned = 1
             frame.icon = CreateFrame("Frame", nil, frame)
             frame.icon:SetFrameStrata("HIGH")


### PR DESCRIPTION
Sometimes `frame:GetName()` returns `nil` so we must check it before call `:find()` or an `attempt to index a nil value` error will be threw.

However, the Pull Request https://github.com/project-classic/ClassicCodex/pull/36 removed this check. So I met this when I was standing next to the Orgrimmar Flight Manager and do a `/reload`:

(Note: Line number is different from current master branch, the file: https://github.com/SwimmingTiger/ClassicCodex/blob/master/quest.lua#L398)
```
3x ClassicCodex\quest.lua:398: attempt to index a nil value
ClassicCodex\quest.lua:398: in function `CheckNamePlate'
ClassicCodex\quest.lua:126: in function <ClassicCodex\quest.lua:28>

Locals:
...
frame = <unnamed> {
 0 = <userdata>
}
...
```

Add the check back and add a comment to avoid subsequent developers deleting it.