### PR TITLE
Fix that quest giver markers don't disappear after accepting tasks

### DIFF
--- a/quest.lua
+++ b/quest.lua
@@ -229,11 +229,13 @@ function CodexQuest:UpdateQuestLog()
     -- process queue
     if CodexConfig.trackingMethod ~= 4  and table.getn(CodexQuest.queue) > 0 then
         for id, entry in pairs(CodexQuest.queue) do
-            if CodexConfig.trackingMethod ~= 3 and (CodexConfig.trackingMethod ~= 2 or IsQuestWatched(entry[3])) then
+            if CodexConfig.trackingMethod ~= 2 or IsQuestWatched(entry[3]) then
                 CodexMap:DeleteNode("CODEX", entry[1])
-                local meta = {["addon"] = "CODEX", ["questLogId"] = entry[3]}
-                for _, id in pairs(entry[2]) do
-                    CodexDatabase:SearchQuestById(id, meta)
+                if CodexConfig.trackingMethod ~= 3 then
+                    local meta = {["addon"] = "CODEX", ["questLogId"] = entry[3]}
+                    for _, id in pairs(entry[2]) do
+                        CodexDatabase:SearchQuestById(id, meta)
+                    end
                 end
                 CodexQuest.updateNodes = true
             end


### PR DESCRIPTION
When tracking method is set to "manual" and "show all quest givers" is selected. Quest giver markers doesn't disapper properly after the player has accepted the task. 

It seems to be that the code to delete these markers are skipped when `trackingMethod` is 3. And this PR makes necessary changes to allow the markers to be removed as expected.